### PR TITLE
Fix duplicate message handling

### DIFF
--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -86,10 +86,14 @@ class Store {
       );
     };
 
+    const messageIds = new Set();
+
     this.serializedPortListener(message => {
-      if (!message || message.channelName !== this.channelName) {
+      if (!message || message.channelName !== this.channelName || messageIds.has(message.messageId)) {
         return;
       }
+
+      messageIds.add(message.messageId);
 
       switch (message.type) {
         case STATE_TYPE:

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -149,10 +149,10 @@ class Store {
    * Replaces the state for only the keys in the updated state. Notifies all listeners of state change.
    * @param {object} state the new (partial) redux state
    */
-  async patchState(difference) {
+  patchState(difference) {
     // Don't attempt a patch if the initial state hasn't been resolved.
-    if (!this.readyResolved) { await this.readyPromise; }
-
+    if (!this.readyResolved) { return; }
+    
     this.state = this.patchStrategy(this.state, difference);
     this.listeners.forEach((l) => l());
   }

--- a/src/wrap-store/wrapStore.js
+++ b/src/wrap-store/wrapStore.js
@@ -144,6 +144,9 @@ export default ({ channelName = defaultOpts.channelName } = defaultOpts) => {
       });
     });
 
+    let lastMsgId = 0;
+    const getNextMessageId = () => `${Date.now()}-${lastMsgId++}`;
+
     let currentState = store.getState();
 
     const forceUpdate = (newState, diff) => {
@@ -152,6 +155,7 @@ export default ({ channelName = defaultOpts.channelName } = defaultOpts) => {
         type: PATCH_STATE_TYPE,
         payload: diff,
         channelName, // Notifying what store is broadcasting the state changes
+        messageId: getNextMessageId()
       });
     };
 
@@ -166,6 +170,7 @@ export default ({ channelName = defaultOpts.channelName } = defaultOpts) => {
           type: PATCH_STATE_TYPE,
           payload: diff,
           channelName, // Notifying what store is broadcasting the state changes
+          messageId: getNextMessageId()
         });
       }
     };
@@ -178,6 +183,7 @@ export default ({ channelName = defaultOpts.channelName } = defaultOpts) => {
       type: STATE_TYPE,
       payload: currentState,
       channelName, // Notifying what store is broadcasting the state changes
+      messageId: getNextMessageId()
     });
 
     /**


### PR DESCRIPTION
This adds a id to every state update sent, ensuring that patches are processed only once by the receiving store. This fixes issues where the receiving end could end up in an invalid state when handling diffs.